### PR TITLE
Added checks for jhead and sift, if not found exit RunBundler.sh

### DIFF
--- a/RunBundler.sh
+++ b/RunBundler.sh
@@ -80,7 +80,7 @@ then
   if [ "$INIT_FOCAL" == "" ]
   then
     # Extract focal lengths using Exif data
-    $EXTRACT_FOCAL list_tmp.txt
+    $EXTRACT_FOCAL list_tmp.txt || exit 1
     cp prepare/list.txt .
   else
     # Use the provided focal length
@@ -93,7 +93,7 @@ fi
 # Run the ToSift script to generate a list of SIFT commands
 echo "[- Extracting keypoints -]"
 rm -f sift.txt
-$TO_SIFT_LIST $IMAGE_LIST > sift.txt 
+$TO_SIFT_LIST $IMAGE_LIST > sift.txt || exit 1
 
 # Execute the SIFT commands
 sh sift.txt
@@ -106,7 +106,7 @@ echo $MATCHKEYS list_keys.txt matches.init.txt $MATCH_WINDOW_RADIUS
 $MATCHKEYS list_keys.txt matches.init.txt $MATCH_WINDOW_RADIUS
 
 # Generate the options file for running bundler 
-mkdir bundle
+mkdir -p bundle
 rm -f options.txt
 
 echo "--match_table matches.init.txt" >> options.txt

--- a/bin/ToSift.sh
+++ b/bin/ToSift.sh
@@ -22,11 +22,9 @@ else
     SIFT=$BIN_PATH/sift
 fi
 
-if [ -e $SIFT ]
-then 
-:
-else
+if ! [ -e $SIFT ] ; then
     echo "[ToSift] Error: SIFT not found.  Please install SIFT to $BIN_PATH" > /dev/stderr
+    exit 1
 fi
 
 for d in `ls -1 $IMAGE_DIR | egrep "jpg$"`

--- a/bin/ToSiftList.sh
+++ b/bin/ToSiftList.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# ToSift.sh
+# ToSiftList.sh
 # Create a script for extracting sift features from a list of images
 
 # Set this variable to your base install path (e.g., /home/foo/bundler)
@@ -21,11 +21,9 @@ else
     SIFT=$BIN_PATH/sift
 fi
 
-if [ -e $SIFT ]
-then 
-:
-else
-    echo "[ToSift] Error: SIFT not found.  Please install SIFT to $BIN_PATH" > /dev/stderr
+if ! [ -e $SIFT ] ; then
+    echo "[ToSiftList] Error: SIFT not found.  Please install SIFT to $BIN_PATH" > /dev/stderr
+    exit 1
 fi
 
 IMAGE_LIST=$1

--- a/bin/extract_focal.pl
+++ b/bin/extract_focal.pl
@@ -18,6 +18,11 @@ if ($OS eq "Cygwin") {
     $JHEAD_EXE = "$BIN_PATH/jhead";
 }
 
+unless (-e $JHEAD_EXE) {
+  printf("[extract_focal] Error: jhead not found.  Please install jhead to %s\n", $BIN_PATH);
+  exit(1);
+}
+
 $OUT_DIR = "./prepare";
 
 $SCALE=1.0;
@@ -293,7 +298,7 @@ $SCALE=1.0;
      "SONY DSC-W80"                     => 5.75,   # 1/2.5"
 );
 
-`mkdir $OUT_DIR`;
+`mkdir -p $OUT_DIR`;
 `rm -f $OUT_DIR/list.txt`;
 
 print "$#ARGV\n";


### PR DESCRIPTION
If you run RunBundler.sh without remembering to copy sift and jhead into the bin directory, RunBundler.sh will continue to run, eventually invoking bundler causing an assertion failure.
