### PR TITLE
ignore the compiled binaries and temporary library files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,21 @@
 
 # emacs temp files
 *~
+
+# Compiled binaries and temporary library files
+bin/Bundle2PMVS
+bin/Bundle2Ply
+bin/Bundle2Vis
+bin/KeyMatchFull
+bin/RadialUndistort
+bin/bundler
+lib/ann_1.1_char/lib
+lib/f2c/arith.h
+lib/f2c/signal1.h
+lib/f2c/sysdep1.h
+src/Bundle2PMVS
+src/Bundle2Ply
+src/Bundle2Vis
+src/KeyMatchFull
+src/RadialUndistort
+src/bundler


### PR DESCRIPTION
Update the .gitignore file, built under Fedora 20 with Ceres enabled.
