### PR TITLE
Fix bug when reading options file in BundlerApp

### DIFF
--- a/src/BundlerApp.cpp
+++ b/src/BundlerApp.cpp
@@ -689,7 +689,8 @@ void BundlerApp::ProcessOptions(int argc, char **argv)
 		}
 
 		char *opt_str = new char[4096];
-		fread(opt_str, 1, 4096, f);
+		int nbytes = fread(opt_str, 1, 4095, f);
+		opt_str[nbytes] = '\0';
 		fclose(f);
 
                 std::string str(opt_str);


### PR DESCRIPTION
The options file is read using `fread()` function, which does not add '\0' at the end of the string. 
As a consequence, memory garbage can be included at the end of the string and produce errors during the parsing process.

This patch fixes it.
