### PR TITLE
Bundler.py: removed unused import

### DIFF
--- a/utils/bundler.py
+++ b/utils/bundler.py
@@ -24,7 +24,6 @@ import argparse
 import gzip
 import os
 import sys
-import Image
 import glob
 import subprocess
 import tempfile


### PR DESCRIPTION
The Image import is useless, because it's being hidden by the Image
symbol imported from the PIL library a couple of lines below.