### PR TITLE
Build with BundleCeres for windows system

### DIFF
--- a/src/BundleCeres.cpp
+++ b/src/BundleCeres.cpp
@@ -7,7 +7,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <float.h>
-#include <sys/time.h>
+//#include <sys/time.h>	//UNIX
+#include "time_unix.h"	//WINDOWS
 
 #include "matrix.h"
 #include "qsort.h"
@@ -19,6 +20,7 @@
 
 #include <ceres/ceres.h>
 #include "snavely_reprojection_error.h"
+#include "ceres/rotation.h"
 
 #include <omp.h>
 
@@ -232,8 +234,9 @@ double BundlerApp::RunSFM_Ceres(int num_pts, int num_cameras,
             double axis[3]; //, angle;
             // double RT[9];
             // matrix_transpose(3, 3, init_camera_params[i].R, RT);
-            rot2aa(init_camera_params[i].R, axis); // , &angle);
+            //rot2aa(init_camera_params[i].R, axis); // , &angle);
             // matrix_scale(3, 1, axis, angle, axis);
+			ceres::RotationMatrixToAngleAxis(init_camera_params[i].R, axis);
 
             double *c = init_camera_params[i].t;
             double t[3];
@@ -468,7 +471,8 @@ double BundlerApp::RunSFM_Ceres(int num_pts, int num_cameras,
 
             // axis_angle_to_matrix(axis, angle, init_camera_params[i].R);
             double RT[9];
-            aa2rot(axis, RT);
+            //aa2rot(axis, RT);
+			ceres::AngleAxisToRotationMatrix(axis, RT);
             matrix_transpose(3, 3, RT, init_camera_params[i].R);
 
             double t[3];

--- a/src/BundleCeres.cpp
+++ b/src/BundleCeres.cpp
@@ -234,9 +234,8 @@ double BundlerApp::RunSFM_Ceres(int num_pts, int num_cameras,
             double axis[3]; //, angle;
             // double RT[9];
             // matrix_transpose(3, 3, init_camera_params[i].R, RT);
-            //rot2aa(init_camera_params[i].R, axis); // , &angle);
+            rot2aa(init_camera_params[i].R, axis); // , &angle);
             // matrix_scale(3, 1, axis, angle, axis);
-			ceres::RotationMatrixToAngleAxis(init_camera_params[i].R, axis);
 
             double *c = init_camera_params[i].t;
             double t[3];
@@ -471,8 +470,7 @@ double BundlerApp::RunSFM_Ceres(int num_pts, int num_cameras,
 
             // axis_angle_to_matrix(axis, angle, init_camera_params[i].R);
             double RT[9];
-            //aa2rot(axis, RT);
-			ceres::AngleAxisToRotationMatrix(axis, RT);
+            aa2rot(axis, RT);
             matrix_transpose(3, 3, RT, init_camera_params[i].R);
 
             double t[3];

--- a/src/BundleCeres.cpp
+++ b/src/BundleCeres.cpp
@@ -7,9 +7,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <float.h>
-//#include <sys/time.h>	//UNIX
-#include "time_unix.h"	//WINDOWS
-
+#if defined(_WIN32) || defined(_WIN64)
+#include "time_unix.h"	
+#else
+#include <sys/time.h>
+#endif
 #include "matrix.h"
 #include "qsort.h"
 #include "util.h"

--- a/src/time_unix.cpp
+++ b/src/time_unix.cpp
@@ -1,0 +1,22 @@
+#include "time_unix.h"
+
+int gettimeofday(struct timeval * tp, struct timezone * tzp)
+{
+	// Note: some broken versions only have 8 trailing zero's, the correct epoch has 9 trailing zero's
+	// This magic number is the number of 100 nanosecond intervals since January 1, 1601 (UTC)
+	// until 00:00:00 January 1, 1970 
+	static const uint64_t EPOCH = ((uint64_t)116444736000000000ULL);
+
+	SYSTEMTIME  system_time;
+	FILETIME    file_time;
+	uint64_t    time;
+
+	GetSystemTime(&system_time);
+	SystemTimeToFileTime(&system_time, &file_time);
+	time = ((uint64_t)file_time.dwLowDateTime);
+	time += ((uint64_t)file_time.dwHighDateTime) << 32;
+
+	tp->tv_sec = (long)((time - EPOCH) / 10000000L);
+	tp->tv_usec = (long)(system_time.wMilliseconds * 1000);
+	return 0;
+}

--- a/src/time_unix.h
+++ b/src/time_unix.h
@@ -1,0 +1,17 @@
+#pragma once
+//original
+//https://stackoverflow.com/questions/10905892/equivalent-of-gettimeday-for-windows
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include <stdint.h> // portable: uint64_t   MSVC: __int64 
+
+#undef ERROR
+
+// MSVC defines this in winsock2.h!?
+typedef struct timeval {
+	long tv_sec;
+	long tv_usec;
+} timeval;
+
+int gettimeofday(struct timeval * tp, struct timezone * tzp);


### PR DESCRIPTION
As I mentioned in Issues, these two files (time-unix.h and time-unix.cpp) are needed for building with windows system.
Also I found difference between rot2aa() and ceres::RotationMatrixToAngleAxis and between aa2rot() and ceres::AngleAxisToRotationMatrix.
The sign is different in the output of each function
![image](https://user-images.githubusercontent.com/18112437/39093475-34f8313e-465b-11e8-8754-3a3e54b0cbea.png)
